### PR TITLE
Fix String issues introduced in β5

### DIFF
--- a/DVR/SessionDataTask.swift
+++ b/DVR/SessionDataTask.swift
@@ -44,7 +44,7 @@ class SessionDataTask: NSURLSessionDataTask {
 		}
 
         // Create directory
-        let outputDirectory = session.outputDirectory.stringByExpandingTildeInPath
+        let outputDirectory = (session.outputDirectory as NSString).stringByExpandingTildeInPath
         let fileManager = NSFileManager.defaultManager()
         if !fileManager.fileExistsAtPath(outputDirectory) {
             try! fileManager.createDirectoryAtPath(outputDirectory, withIntermediateDirectories: true, attributes: nil)
@@ -65,7 +65,7 @@ class SessionDataTask: NSURLSessionDataTask {
 
             // Persist
             do {
-                let outputPath = outputDirectory.stringByAppendingPathComponent(self.session.cassetteName).stringByAppendingPathExtension("json")!
+                let outputPath = ((outputDirectory as NSString).stringByAppendingPathComponent(self.session.cassetteName) as NSString).stringByAppendingPathExtension("json")!
                 let data = try NSJSONSerialization.dataWithJSONObject(cassette.dictionary, options: [.PrettyPrinted])
                 data.writeToFile(outputPath, atomically: true)
                 fatalError("[DVR] Persisted cassette at \(outputPath). Please add this file to your test target")


### PR DESCRIPTION
As I promised - here's a **PR** which fixes lack of _path-related_ methods from `String` struct.

@czechboy0 it looks like we're a way way behind the `venmo/DVR`'s `master`.
